### PR TITLE
set up "official" course CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,9 @@
+on: [push]
+
+jobs:
+  verify-course:
+    runs-on: ubuntu-latest
+    name: Verify course
+    steps:
+      - uses: actions/checkout@v2
+      - uses: LibreLingo/course-ci@main


### PR DESCRIPTION
This introduces a new github actions workflow file that will run these checks automatically on each pushed change: https://github.com/LibreLingo/course-ci

that is a central place to host CI configuration for courses. for now it has very basic functionality (it will fail, if the course cannot be built/deployed) but further functionality can be added. I can see that in this repo you already have some more advanced functionality. Probably that can be moved to https://github.com/LibreLingo/course-ci and then it will be automatically available to all course repos